### PR TITLE
Iterate over known linux ca bundle paths

### DIFF
--- a/ca_certs_locater.py
+++ b/ca_certs_locater.py
@@ -16,7 +16,13 @@
 
 import os
 
-LINUX_PATH = '/etc/ssl/certs/ca-certificates.crt'
+LINUX_PATHS = (
+    '/etc/ssl/certs/ca-certificates.crt',                # Debian/Ubuntu/Gentoo etc.
+    '/etc/pki/tls/certs/ca-bundle.crt',                  # Fedora/RHEL 6
+    '/etc/ssl/ca-bundle.pem',                            # OpenSUSE
+    '/etc/pki/tls/cacert.pem',                           # OpenELEC
+    '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'  # CentOS/RHEL 7
+)
 
 
 def get():
@@ -24,8 +30,9 @@ def get():
     """
     # FIXME(dhellmann): Assume Linux for now, add more OSes and
     # platforms later.
-    if os.path.exists(LINUX_PATH):
-        return LINUX_PATH
+    for path in LINUX_PATHS:
+        if os.path.exists(path):
+            return path
     # Fall back to the httplib2 default behavior by raising an
     # ImportError if we have not found the file.
     raise ImportError()

--- a/test_ca_certs_locater.py
+++ b/test_ca_certs_locater.py
@@ -13,7 +13,7 @@ class TestLocator(unittest.TestCase):
         # If the file exists, return it
         exists.return_value = True
         fn = ca_certs_locater.get()
-        self.assertEqual(fn, ca_certs_locater.LINUX_PATH)
+        self.assertEqual(fn, ca_certs_locater.LINUX_PATHS[0])
 
     @ mock.patch('os.path.exists')
     def test_linux_does_not_exist(self, exists):


### PR DESCRIPTION
As suggested by @joemiller
https://github.com/dreamhost/httplib2-ca_certs_locater/issues/1